### PR TITLE
Removing unneccesary install steps in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language : node_js
 node_js :
  - stable
-install:
- - npm install
- - npm i typescript
+# install:
+#  - npm install
+#  - npm i typescript
 script:
  - npm run build
  - npm run cover 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language : node_js
 node_js :
  - stable
-# install:
-#  - npm install
-#  - npm i typescript
 script:
  - npm run build
  - npm run cover 


### PR DESCRIPTION
Running npm install and installing typescript is all getting handled by npm itself + the definition of the "prepare" command in package.json